### PR TITLE
Fix(test): Configure test script to run accessibility audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,18 +4,10 @@
   "description": "Accessibility audit for the Unreal Engine guide page.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node run-axe.js"
   },
   "keywords": [],
-feature/create-unreal-guide-page
   "author": "Kuonirad",
-
-feature/create-unreal-guide-page
-  "author": "Kuonirad",
-
-  "author": "",
-
- main
   "license": "ISC",
   "dependencies": {
     "axe-core": "^4.10.3",


### PR DESCRIPTION
The `test` script in `package.json` was not configured to run any tests. It was set to the default `echo "Error: no test specified" && exit 1`.

This change updates the `test` script to execute the accessibility audit using `node run-axe.js`. This allows developers to run the project's primary verification mechanism using the standard `npm test` command.

This commit also cleans up the `package.json` file by removing extraneous lines that were likely the result of a previous merge conflict.